### PR TITLE
Update README to correct Swift Package Manager dependency URL for Reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See additional [resources](#resources) below.
 
 ### Swift Package Manager
 
-Add Reaper as a dependency with Swift package manager using the URL https://github.com/EmergeTools/Reaper
+Add Reaper as a dependency with Swift package manager using the URL https://github.com/getsentry/Reaper-iOS.git
 
 ### CocoaPods
 


### PR DESCRIPTION
Xcode is unable to fetch the old SPM Link