### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     
     - name: Modify Package.swift for dynamic library
       run: |
@@ -57,7 +57,7 @@ jobs:
         zip -r Reaper.xcframework.zip Reaper.xcframework
         
     - name: Upload XCFramework artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: Reaper.xcframework
         path: build/Reaper.xcframework.zip


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)